### PR TITLE
use setlocal instead of setfiletype

### DIFF
--- a/ftdetect/vgo.vim
+++ b/ftdetect/vgo.vim
@@ -2,6 +2,6 @@
 " Use of this source code is governed by a BSD-style
 " license that can be found in the LICENSE file.
 
-autocmd BufNewFile,BufRead go.mod setfiletype vgo
+autocmd BufNewFile,BufRead go.mod setlocal filetype=vgo
 
 " vim: sts=2:sw=2:ts=2:et


### PR DESCRIPTION
setfiletype doesn't change anything when filetype option is already set. Vim set filetype=lprorog for `*.mod`  in default.